### PR TITLE
feat: add redirect_http_to_https for redirecting collector HTTP requests to HTTPS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "google_compute_url_map" "lb_url_map" {
 resource "google_compute_target_http_proxy" "lb_target_http_proxy" {
   name = "${var.name}-http-proxy"
 
-  url_map = google_compute_url_map.lb_url_map.self_link
+  url_map = var.redirect_http_to_https ? google_compute_url_map.http_to_https_redirect[0].self_link : google_compute_url_map.lb_url_map.self_link
 }
 
 resource "google_compute_ssl_policy" "lb_target_https_ssl_policy" {
@@ -70,18 +70,10 @@ resource "google_compute_url_map" "http_to_https_redirect" {
   }
 }
 
-resource "google_compute_target_http_proxy" "http_to_https_redirect" {
-  count = var.redirect_http_to_https ? 1 : 0
-
-  name    = "http-redirect"
-  
-  url_map = google_compute_url_map.http_to_https_redirect[0].self_link
-}
-
 resource "google_compute_global_forwarding_rule" "lb_http_forwarding_rule" {
   name = "${var.name}-http-frontend"
 
-  target     = var.redirect_http_to_https ? google_compute_target_http_proxy.http_to_https_redirect[0].self_link : google_compute_target_http_proxy.lb_target_http_proxy.self_link
+  target     = google_compute_target_http_proxy.lb_target_http_proxy.self_link
   port_range = "80"
   ip_address = google_compute_global_address.ip.address
 }

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "google_compute_global_address" "ip" {
   name = var.name
 }
 
-resource "google_compute_url_map" "http-to-https-redirect" {
+resource "google_compute_url_map" "http_to_https_redirect" {
   count = var.redirect_http_to_https ? 1 : 0
   
   name = "http-redirect"
@@ -70,18 +70,18 @@ resource "google_compute_url_map" "http-to-https-redirect" {
   }
 }
 
-resource "google_compute_target_http_proxy" "http-to-https-redirect" {
+resource "google_compute_target_http_proxy" "http_to_https_redirect" {
   count = var.redirect_http_to_https ? 1 : 0
 
   name    = "http-redirect"
   
-  url_map = google_compute_url_map.http-to-https-redirect[0].self_link
+  url_map = google_compute_url_map.http_to_https_redirect[0].self_link
 }
 
 resource "google_compute_global_forwarding_rule" "lb_http_forwarding_rule" {
   name = "${var.name}-http-frontend"
 
-  target     = var.redirect_http_to_https ? google_compute_target_http_proxy.http-to-https-redirect[0].self_link : google_compute_target_http_proxy.lb_target_http_proxy.self_link
+  target     = var.redirect_http_to_https ? google_compute_target_http_proxy.http_to_https_redirect[0].self_link : google_compute_target_http_proxy.lb_target_http_proxy.self_link
   port_range = "80"
   ip_address = google_compute_global_address.ip.address
 }
@@ -95,3 +95,6 @@ resource "google_compute_global_forwarding_rule" "lb_https_forwarding_rule" {
   port_range = "443"
   ip_address = google_compute_global_address.ip.address
 }
+
+
+

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,9 @@ variable "ssl_min_tls_version" {
   default     = "TLS_1_2"
   type        = string
 }
+
+variable "redirect_http_to_https" {
+  description = "A boolean which makes the HTTP proxy for the collector redirect to HTTPS"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
I don't know if this PR is of interest, but it's a modification I am currently using.

This PR adds the input variable `redirect_http_to_https` which will configure the collector HTTP proxy to redirect to HTTPS. The option can only be enabled if `ssl_certificate_enabled` is true, using a workaround from the Terraform bug tracker (https://github.com/hashicorp/terraform/issues/31122). 

The main scenarios I've looked at are listed below.

1. The scenario where no value is specified for `redirect_http_to_https` (it will default to false) on an existing deploy. The only changes it picked up were the `terraform-data` resource (necesary workaround for the validation to work). 
<img width="1093" alt="image" src="https://github.com/snowplow-devops/terraform-google-lb/assets/8135257/a2a7eea7-e28c-4c7b-a1f2-7800c6f4220b">

2. The scenario where `ssl_certificate_enabled` is false and `redirect_http_to_https` is true, the deploy failed with the expected valdiation error (it didn't get passed `terraform plan`).
<img width="1251" alt="image" src="https://github.com/snowplow-devops/terraform-google-lb/assets/8135257/498c8747-782b-4db9-a643-ab877917fcb1">

3. The scenario where `ssl_certificate_enabled` is true and `redirect_http_to_https` is true. The deployed infrastructure will redirect an HTTP request to the collector to HTTPS using a 301. Tested using Curl in within a web browser.