### PR TITLE
fix: google_compute_url_map needs a unique name per module instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ resource "google_compute_global_address" "ip" {
 resource "google_compute_url_map" "http_to_https_redirect" {
   count = local.redirect_http_to_https ? 1 : 0
 
-  name = "http-redirect"
+  name = "${var.name}-http-redirect"
 
   default_url_redirect {
     redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"


### PR DESCRIPTION
I hit an issue in my project where having two instances of this module - that both upgrade HTTP to HTTPS - would cause a 409 naming conflict from GCP. My previous PR set the "google_compute_url_map" name/prefix to just "http-redirect", rather than prefixing it with the name/prefix parameter.

